### PR TITLE
Fix: use _X. instead of _.

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -329,7 +329,7 @@ function callrecording_get_config($engine) {
 		$ext->add($context, $exten, '', new ext_return(''));
 
 		$id = 'sub-record-hh-check';
-		$c = '_.';
+		$c = '_X.';
 		$ext->add($id, $c, '', new ext_noop('Callee: ${MIXMONITOR_FILENAME}'));
 		$ext->add($id, $c, 'exit', new ext_return());
 


### PR DESCRIPTION
The use of _. seems to be discouraged.

"pbx_load_config: The use of '_.' for an extension is strongly discouraged and can have unexpected behavior.  Please use '_X.' instead at line 207 of /etc/asterisk/extensions_additional.conf"